### PR TITLE
Only install epel on Centos or RHEL, Fedora does not need epel

### DIFF
--- a/ansible/roles/telemetry.qdr-deployer/tasks/main.yml
+++ b/ansible/roles/telemetry.qdr-deployer/tasks/main.yml
@@ -5,6 +5,7 @@
   package:
     name: epel-release
     state: present
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'
 
 - name: Install package dependencies
   become: true


### PR DESCRIPTION
Fedora will complain bitterly