### PR TITLE
Change default root paths out of /root/

### DIFF
--- a/ansible/roles/telemetry.barometer-deployer/defaults/main.yml
+++ b/ansible/roles/telemetry.barometer-deployer/defaults/main.yml
@@ -2,6 +2,7 @@
 barometer_host: 127.0.0.1
 barometer_port: 5672
 barometer_interval: 5
+barometer_root_config_path: /opt/sa/barometer-collectd.conf.d
 barometer_image: nfvpe/barometer-collectd
 barometer_image_tag: latest
 barometer_plugin_connectivity_interfaces:

--- a/ansible/roles/telemetry.barometer-deployer/tasks/main.yml
+++ b/ansible/roles/telemetry.barometer-deployer/tasks/main.yml
@@ -7,12 +7,12 @@
 - name: Create directory for barometer-collectd configuration
   file:
     state: directory
-    path: "{{ ansible_env.HOME }}/barometer-collectd.conf.d"
+    path: "{{ barometer_root_config_path }}"
 
 - name: Deploy configuration for barometer-collectd on client
   template:
     src: "{{ item }}.conf.j2"
-    dest: "{{ ansible_env.HOME }}/barometer-collectd.conf.d/{{ item }}.conf"
+    dest: "{{ barometer_root_config_path }}/{{ item }}.conf"
   with_items:
     - default
     - amqp1
@@ -29,7 +29,7 @@
     network_mode: host
     entrypoint: /sbin/collectd -f -C /opt/collectd/etc/collectd.conf.d/
     volumes:
-      - "{{ ansible_env.HOME }}/barometer-collectd.conf.d/:/opt/collectd/etc/collectd.conf.d/"
+      - "{{ barometer_root_config_path }}/:/opt/collectd/etc/collectd.conf.d/"
       - /var/run:/var/run
       - /tmp:/tmp
     restart: yes

--- a/ansible/roles/telemetry.qdr-deployer/defaults/main.yml
+++ b/ansible/roles/telemetry.qdr-deployer/defaults/main.yml
@@ -2,6 +2,7 @@
 qdr_dns_servers: 10.19.110.9
 qdr_image: nfvpe/qpid-dispatch-router
 qdr_image_tag: 1.2.0-2
+qdr_root_config_path: /opt/sa/qdr.conf.d
 
 router:
     id_prefix: BAROMETER_ROUTER

--- a/ansible/roles/telemetry.qdr-deployer/tasks/main.yml
+++ b/ansible/roles/telemetry.qdr-deployer/tasks/main.yml
@@ -41,19 +41,19 @@
 - name: Create directory for QDR configuration
   file:
     state: directory
-    path: "{{ ansible_env.HOME }}/qdr.conf.d"
+    path: "{{ qdr_root_config_path }}"
 
 - name: Deploy configuration for QDR on client
   template:
     src: qdrouterd.conf.j2
-    dest: "{{ ansible_env.HOME }}/qdr.conf.d/qdrouterd.conf"
+    dest: "{{ qdr_root_config_path }}/qdrouterd.conf"
 
 - name: Start QDR container (cloud side)
   docker_container:
     name: qdr
     image: "{{ qdr_image }}:{{ qdr_image_tag }}"
     exposed_ports: 5672/tcp
-    volumes: "{{ ansible_env.HOME }}/qdr.conf.d/:/etc/qdr.conf.d/:Z"
+    volumes: "{{ qdr_root_config_path }}/:/etc/qdr.conf.d/:Z"
     dns_servers: "{{ qdr_dns_servers }}"
     network_mode: host
     restart: yes


### PR DESCRIPTION
Change the default configuration paths out of the the /root/ directory
(via ansible_env.HOME) and instead create a default configuration path
via /opt/sa/ for the barometer-collectd.conf.d and qdr.conf.d configuration
paths.